### PR TITLE
Fixed a bug in the min and max timestamp in media/search

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -689,13 +689,13 @@ var instagram = function(spec, my) {
 
     if(options.max_timestamp) {
       if(options.max_timestamp > parseInt(Date.now() / 1000, 10)) {
-        options.max_timestamp = parseInt(options.max_timestamp / 1000, 10);
+        options.max_timestamp = parseInt(Date.now() / 1000, 10);
       }
       params.max_timestamp = options.max_timestamp;
     }
     if(options.min_timestamp) {
       if(options.min_timestamp > parseInt(Date.now() / 1000, 10)) {
-        options.min_timestamp = parseInt(options.min_timestamp / 1000, 10);
+        options.min_timestamp = parseInt(Date.now() / 1000, 10);
       }
       params.min_timestamp = options.min_timestamp;
     }


### PR DESCRIPTION
If either of the min timestamp or max timestamp were later than the current date, they would be assigned themselves / 1000, instead of Date.now() / 1000.

This is now resolved.
