### PR TITLE
Opening up the option to supply a different instagram api hostname. 

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -31,7 +31,7 @@ var crypto = require('crypto');
  * Proceeds the call to the API and give
  * back the response
  *
- * @param spec { agent }
+ * @param spec { agent, host }
  */
 var instagram = function(spec, my) {
   var _super = {};
@@ -41,6 +41,7 @@ var instagram = function(spec, my) {
   my.limit = null;
   my.remaining = null;
   my.agent = spec.agent;
+  my.host = spec.host || 'api.instagram.com';
 
   // public
   var use;                              /* use(spec);                                       */
@@ -125,7 +126,7 @@ var instagram = function(spec, my) {
       }
 
       var options = {
-        host: 'api.instagram.com',
+        host: my.host,
         method: method,
         path: '/v1' + path + (method === 'GET' || method === 'DELETE' ? '?' + query.stringify(params) : ''),
         agent: my.agent
@@ -1371,7 +1372,7 @@ var instagram = function(spec, my) {
    */
   get_authorization_url = function(redirect_uri, options) {
     var options = options || {};
-    var url_obj = url.parse('https://api.instagram.com');
+    var url_obj = url.parse('https://' + my.host);
     url_obj.pathname = '/oauth/authorize';
 
     if(!my.auth.client_id || !my.auth.client_secret) {


### PR DESCRIPTION
Consider writing a web app that interacts with the Instagram API. It can be advantageous to write a mock Instagram API that implements some subset of the real Instagram API for things like load testing. 

I am doing exactly this. Thus, I need the ability to point instagram-node at a host other than 'api.instagram.com'

This PR opens instagram-node so as to accept any Instagram API hostname, while defaulting to 'api.instagram.com' when no override is provided.

Thanks.
