### PR TITLE
Opening option to use Instagram API with port other than 80

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -42,6 +42,7 @@ var instagram = function(spec, my) {
   my.remaining = null;
   my.agent = spec.agent;
   my.host = spec.host || 'https://api.instagram.com';
+  my.port = spec.port || 443;
 
   // public
   var use;                              /* use(spec);                                       */
@@ -127,7 +128,7 @@ var instagram = function(spec, my) {
 
       var options = {
         host: url.parse(my.host).hostname,
-        port: url.parse(my.host).port || 443,
+        port: my.port,
         method: method,
         path: '/v1' + path + (method === 'GET' || method === 'DELETE' ? '?' + query.stringify(params) : ''),
         agent: my.agent


### PR DESCRIPTION
In accordance with ddcb11ac62255ff3e41e8528aadee27684b71d94 I ran into some trouble hosting my Instagram Mock API anywhere but port 80. This resolves said issue.

Thanks.
