### PR TITLE
Fix pagination result

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -1146,11 +1146,11 @@ var instagram = function(spec, my) {
       if(err) {
         return handle_error(err, cb, retry);
       } else if(result && result.meta && result.meta.code === 200) {
-        if(result.pagination && result.pagination.next_max_tag_id) {
+        if(result.pagination && result.pagination.next_max_id) {
           options = fwk.shallow(options);
           // Syntax weirdness coming from IG API (max_tag_id instead of max_id)
           // [see http://instagram.com/developer/endpoints/tags/]
-          options.max_tag_id = result.pagination.next_max_tag_id;
+          options.max_tag_id = result.pagination.next_max_id;
           var next = function(cb) {
             tag_media_recent(tag, options, cb);
           };


### PR DESCRIPTION
Looks like instagram has changed the pagination result object. Currently the pagination.next() function is never set.
https://instagram.com/developer/endpoints/

Pagination returns now next_max_id instead of next_max_tag_id.