### PR TITLE
Fixed path for personal feed

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -400,7 +400,7 @@ var instagram = function(spec, my) {
       params.max_id = options.max_id;
     }
 
-    call('GET', '/users/self/feed', params, function(err, result, remaining, limit) {
+    call('GET', '/users/self/media/recent', params, function(err, result, remaining, limit) {
       if(err) {
         return handle_error(err, cb, retry);
       } else if(result && result.meta && result.meta.code === 200) {


### PR DESCRIPTION
Path to personal feed was giving a 404 Page Not Found error.
Fixed the URL to the correct path.
