### PR TITLE
Add res.send() at the end of authorize_user()

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -1478,6 +1478,8 @@ var instagram = function(spec, my) {
         return handle_error(result, cb, retry);
       }
     }, retry);
+
+    res.end('Authorization succeeded');
   };
 
   /**


### PR DESCRIPTION
This avoid leaving the  authorize_user() hanging.
This edit allowed my app to avoid "Application Failure" bug from Instagram
