### PR TITLE
fix: Added required 'Host' header to support proxy requests

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -157,7 +157,9 @@ var instagram = function(spec, my) {
         method: method,
         path: '/v1' + path + (method === 'GET' || method === 'DELETE' ? '?' + query.stringify(params) : ''),
         agent: my.agent,
-        headers: {}
+        headers: {
+          Host: url.parse(my.host).hostname,
+        }
       };
 
       // oauth and oembed calls don't use /v1


### PR DESCRIPTION
Hi,
i found a problem using the lib with a proxy because of the missing required `Host` header. This solves my problem in totemstech/instagram-node#67.
