### PR TITLE
prevent cb to be called twice in some error case

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -166,6 +166,7 @@ var instagram = function(spec, my) {
       }
 
       var data = null;
+      var hasError = false;
 
       if (method !== 'GET' && method !== 'DELETE') {
         data = query.stringify(params);
@@ -182,6 +183,7 @@ var instagram = function(spec, my) {
         });
 
         res.on('end', function() {
+          if (hasError) return;
           var result;
           var limit = parseInt(res.headers['x-ratelimit-limit'], 10) || 0;
           var remaining = parseInt(res.headers['x-ratelimit-remaining'], 10) || 0;
@@ -199,6 +201,7 @@ var instagram = function(spec, my) {
       });
 
       req.on('error', function(err) {
+        hasError = true;
         return handle_error(err, cb, retry);
       });
 


### PR DESCRIPTION
prevent cb to be called twice in some error case.

For exemple : when the error ECONRESET is thrown the callback was called twice.
