### PR TITLE
Instagram api authorization clearing client_id and secret fixed

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -326,12 +326,7 @@ var instagram = function(spec, my) {
       if(options.access_token) {
         my.limit = null;
         my.remaining = null;
-        my.auth = {
-          access_token: options.access_token
-        };
-        if (options.client_secret) {
-          my.auth.client_secret = options.client_secret;
-        }
+        my.auth.access_token = options.access_token;
       } else if(options.client_id && options.client_secret) {
         my.limit = null;
         my.remaining = null;


### PR DESCRIPTION
When the client is authorization is done first time, it clears the client_id and client_secret of the configuration and because of that authorization again doesn't happen.